### PR TITLE
fix incorrect pointer casting and dereferencing in buffer initialization

### DIFF
--- a/pylzss.c
+++ b/pylzss.c
@@ -149,8 +149,8 @@ int lzss_encode(struct lzss_io *io, unsigned int initial_buffer_byte_values)
 	for (i = s; i < r; i++) {
 		/* Clear the buffer with
 		any character that will appear often. */
-		ctx.text_buf[i] = (unsigned char*)(&initial_buffer_byte_values)[i%4];
-        }
+		ctx.text_buf[i] = ((unsigned char *)&initial_buffer_byte_values)[i%4];
+    }
 
 	for (len = 0; len < F && ((c = io->rd(io->i)) != EOF); len++)
 		ctx.text_buf[r + len] = c;  /* Read F bytes into the last F bytes of
@@ -219,7 +219,7 @@ int lzss_decode(struct lzss_io *io, unsigned int initial_buffer_byte_values)
 	unsigned int  flags;
 	unsigned char text_buf[N + F - 1];
 	
-	for (i = 0; i < N - F; i++) text_buf[i] = (unsigned char*)(&initial_buffer_byte_values)[i%4];
+	for (i = 0; i < N - F; i++) text_buf[i] = ((unsigned char *)&initial_buffer_byte_values)[i%4];
 	r = N - F;  flags = 0;
 	for ( ; ; ) {
 		if (((flags >>= 1) & 256) == 0) {


### PR DESCRIPTION
In the current implementation of both the encoding and decoding routines, there is a critical error related to how `initial_buffer_byte_values` is cast and accessed.

It attempts to cast the address of the unsigned integer `initial_buffer_byte_values` to a pointer to `unsigned char`, and then indexes into it.

This casting and subsequent pointer arithmetic is intended to access each byte of the integer to initialize `ctx.text_buf`. However, the syntax used leads to undefined behavior due to incorrect pointer casting and dereferencing.

@yyogo
@m1stadev
